### PR TITLE
misc cleanup

### DIFF
--- a/js/src/runtime/PathPrefixes.ts
+++ b/js/src/runtime/PathPrefixes.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** This object's property names are referenced by the Java code; do not change them. */
+export const PathPrefixes = Object.freeze({
+    lib: "/lib/",
+    app: "/app/",
+});

--- a/js/src/runtime/vfs.ts
+++ b/js/src/runtime/vfs.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as ts from "typescript";
+import * as tsvfs from "@typescript/vfs";
+import { PathPrefixes } from "./PathPrefixes";
+
+export type VfsOptions = {
+    readonly traceVirtualFileSystem?: boolean;
+};
+
+export function createCompilerHost(
+    vfsOptions: VfsOptions,
+    compilerOptions: ts.CompilerOptions,
+    allFiles: Map<string, string>,
+) {
+    const system = createVirtualFileSystem(vfsOptions, allFiles);
+    const host = tsvfs.createVirtualCompilerHost(system, compilerOptions, ts).compilerHost;
+    const getSourceFile = host.getSourceFile;
+
+    host.getSourceFile = (filename, ...args) => {
+        if (!host.fileExists(filename)) {
+            return;
+        } else {
+            return getSourceFile(filename, ...args);
+        }
+    };
+    host.getDefaultLibLocation = () => PathPrefixes.lib;
+    host.getDefaultLibFileName = (compilerOptions) =>
+        PathPrefixes.lib + ts.getDefaultLibFileName(compilerOptions);
+
+    return host;
+}
+
+function createVirtualFileSystem(vfsOptions: VfsOptions, allFiles: Map<string, string>) {
+    const system = tsvfs.createSystem(allFiles);
+
+    if (vfsOptions.traceVirtualFileSystem) {
+        const readFile = system.readFile;
+        if (readFile) {
+            system.readFile = function (...[filename, ...args]: Parameters<typeof readFile>) {
+                console.error("system.readFile(", filename, ...args, ")");
+                const result = readFile(filename, ...args);
+                if (result === undefined && allFiles.has(filename)) {
+                    return allFiles.get(filename);
+                }
+                return result;
+            };
+        } else {
+            console.error("*** no system.readFile");
+        }
+
+        const fileExists = system.fileExists;
+        system.fileExists = function (path) {
+            console.error("system.fileExists(" + path + ")");
+            const result = fileExists(path);
+            console.error("--> " + result);
+            return result;
+        };
+
+        const resolvePath = system.resolvePath;
+        system.resolvePath = function (path) {
+            console.error("system.resolvePath(" + path + ")");
+            const result = resolvePath(path);
+            console.error("--> " + result);
+            return result;
+        };
+
+        const realpath = system.realpath;
+        if (realpath) {
+            system.realpath = function (path) {
+                console.error("system.realpath(" + path + ")");
+                const result = realpath(path);
+                console.error("--> " + result);
+                return result;
+            };
+        } else {
+            // for resolving symlinks; assume there are none
+            system.realpath = function (path) {
+                console.error("system.realpath(" + path + ")");
+                const result = path;
+                console.error("--> " + result + " [patched]");
+                return result;
+            };
+        }
+
+        const readDirectory = system.readDirectory;
+        system.readDirectory = function (path, ...args) {
+            console.error("system.readDirectory(" + path + ")");
+            const result = readDirectory.call(system, path, ...args);
+            console.error("--> " + result);
+            return result;
+        };
+
+        const directoryExists = system.directoryExists;
+        system.directoryExists = function (path) {
+            console.error("system.directoryExists(" + path + ")");
+            const result = directoryExists(path);
+            console.error("--> " + result);
+            return result;
+        };
+
+        const getFileSize = system.getFileSize;
+        if (getFileSize) {
+            system.getFileSize = function (path) {
+                console.error("system.getFileSize(" + path + ")");
+                const result = getFileSize(path);
+                console.error("--> " + result);
+                return result;
+            };
+        } else {
+            system.getFileSize = function (path) {
+                console.error("system.getFileSize(" + path + ")");
+                const result = readFile(path)?.length ?? 0;
+                console.error("--> " + result + " [patched]");
+                return result;
+            };
+        }
+    }
+
+    return system;
+}

--- a/src/main/java/com/caoccao/javet/interop/JavetBridge.java
+++ b/src/main/java/com/caoccao/javet/interop/JavetBridge.java
@@ -48,21 +48,21 @@ public final class JavetBridge {
             @Override
             void addReference(IV8ValueReference iV8ValueReference) {
                 super.addReference(iV8ValueReference);
-                String caller = "unknown";
+                StringBuilder sb = new StringBuilder();
                 for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
-                    if (element.toString().startsWith("org.openrewrite")) {
-                        caller = element.toString();
-                        break;
-                    }
+                    sb.append("\t").append(element.toString()).append("\n");
                 }
-                remainingReferences.put(iV8ValueReference.getHandle(), caller);
+                remainingReferences.put(iV8ValueReference.getHandle(), sb.toString());
             }
 
             @Override
             void removeReference(IV8ValueReference iV8ValueReference) throws JavetException {
                 super.removeReference(iV8ValueReference);
-                remainingReferences.remove(iV8ValueReference.getHandle());
+                // Uncommenting this surfaces unmatched references for some reason
+//                remainingReferences.remove(iV8ValueReference.getHandle());
             }
+
+
 
             public void close(boolean forceClose) throws JavetException {
                 if (!isClosed() && forceClose) {
@@ -99,6 +99,13 @@ public final class JavetBridge {
                         } else {
                             // TODO
                             System.err.print(valueV8);
+                        }
+                        try {
+                            if (valueV8.isWeak()) {
+                                System.err.print(" (weak)");
+                            }
+                        } catch (JavetException e) {
+                            throw new RuntimeException(e);
                         }
                         System.err.println();
                         String caller = remainingReferences.get(valueV8.getHandle());

--- a/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
+++ b/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
@@ -93,7 +93,7 @@ public class JavaScriptParser implements Parser<JS.CompilationUnit> {
     public boolean accept(Path path) {
         final String filename = path.getFileName().toString().toLowerCase();
         for (String ext : EXTENSIONS) {
-            if (filename.endsWith(ext)) {
+            if (filename.endsWith("." + ext)) {
                 return true;
             }
         }

--- a/src/main/java/org/openrewrite/javascript/internal/JavetUtils.java
+++ b/src/main/java/org/openrewrite/javascript/internal/JavetUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.internal;
+
+import com.caoccao.javet.values.IV8Value;
+import org.openrewrite.internal.lang.Nullable;
+
+public class JavetUtils {
+    private JavetUtils() {}
+
+    public static void close(@Nullable IV8Value valueV8) {
+        if (valueV8 != null && !valueV8.isClosed()) {
+            try {
+                valueV8.close();
+            } catch (Exception e) {
+                System.err.println("Error while attempting to close V8 value: " + e);
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
+++ b/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
@@ -551,7 +551,7 @@ public class TypeScriptParserVisitor {
         if (node.hasProperty("members")) {
             Space bodyPrefix = sourceBefore(TSCSyntaxKind.OpenBraceToken);
 
-            TSCNodeList<TSCNode> memberNodes = node.getNodeListProperty("members");
+            TSCNodeList memberNodes = node.getNodeListProperty("members");
             if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
                 Space enumPrefix = whitespace();
 

--- a/src/main/java/org/openrewrite/javascript/internal/tsc/TSCConversions.java
+++ b/src/main/java/org/openrewrite/javascript/internal/tsc/TSCConversions.java
@@ -75,11 +75,9 @@ public final class TSCConversions {
 
     public static final TSCConversion<TSCNode> NODE = cached(context -> context.nodeCache);
 
-    static final TSCConversion<TSCNodeList<TSCNode>> NODE_LIST = nodeList(NODE);
+    static final TSCConversion<TSCNodeList> NODE_LIST = cached(context -> context.nodeListCache);
 
     public static final TSCConversion<TSCNode.TypeNode> TYPE_NODE = cast(NODE, TSCNode.TypeNode.class);
-
-    public static final TSCConversion<TSCNodeList<TSCNode.TypeNode>> TYPE_NODE_LIST = nodeList(TYPE_NODE);
 
     public static final TSCConversion<TSCSyntaxListNode> SYNTAX_LIST_NODE = cast(NODE, TSCSyntaxListNode.class);
 
@@ -188,19 +186,6 @@ public final class TSCConversions {
             converted.putAll(collections);
 
             return converted;
-        };
-    }
-
-    static <T extends TSCNode> TSCConversion<TSCNodeList<T>> nodeList(TSCConversion<T> conversion) {
-        return (context, valueV8) -> {
-            if (!(valueV8 instanceof V8ValueArray)) {
-                throw new IllegalStateException("expected a V8 array");
-            }
-
-            V8ValueArray arrayV8 = valueV8.toClone();
-            arrayV8.setWeak();
-
-            return TSCNodeList.wrap(context, arrayV8, conversion);
         };
     }
 

--- a/src/main/java/org/openrewrite/javascript/internal/tsc/TSCGlobals.java
+++ b/src/main/java/org/openrewrite/javascript/internal/tsc/TSCGlobals.java
@@ -15,30 +15,32 @@
  */
 package org.openrewrite.javascript.internal.tsc;
 
+import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.reference.V8ValueObject;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.function.Supplier;
 
-import static org.openrewrite.javascript.internal.tsc.TSCConversions.*;
+import static org.openrewrite.javascript.internal.tsc.TSCConversions.NODE_LIST;
 
-public class TSCGlobals implements TSCV8Backed {
+public class TSCGlobals extends TSCV8ValueHolder implements TSCV8Backed {
 
-    public static TSCGlobals wrap(TSCProgramContext context, V8ValueObject objectV8) {
+    public static TSCGlobals fromJS(Supplier<TSCProgramContext> context, V8ValueObject objectV8) {
         return new TSCGlobals(context, objectV8);
     }
 
-    private final TSCProgramContext programContext;
+    private final Supplier<TSCProgramContext> programContext;
     private final V8ValueObject typescriptV8;
 
-    private TSCGlobals(TSCProgramContext programContext, V8ValueObject typescriptV8) {
+    private TSCGlobals(Supplier<TSCProgramContext> programContext, V8ValueObject typescriptV8) {
         this.programContext = programContext;
-        this.typescriptV8 = typescriptV8;
+        this.typescriptV8 = lifecycleLinked(typescriptV8);
     }
 
     @Override
     public TSCProgramContext getProgramContext() {
-        return programContext;
+        return programContext.get();
     }
 
     @Override

--- a/src/main/java/org/openrewrite/javascript/internal/tsc/TSCObjectCache.java
+++ b/src/main/java/org/openrewrite/javascript/internal/tsc/TSCObjectCache.java
@@ -16,15 +16,12 @@
 package org.openrewrite.javascript.internal.tsc;
 
 import com.caoccao.javet.exceptions.JavetException;
-import com.caoccao.javet.interop.V8Scope;
-import com.caoccao.javet.utils.JavetResourceUtils;
 import com.caoccao.javet.values.reference.V8ValueObject;
 
-import java.io.Closeable;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class TSCObjectCache<T extends TSCV8Backed> implements Closeable {
+public abstract class TSCObjectCache<T extends TSCV8Backed> extends TSCV8ValueHolder {
 
     public interface KeyProvider<TKey> {
         TKey getKey(TSCProgramContext context, V8ValueObject objectV8) throws JavetException;
@@ -44,12 +41,8 @@ public abstract class TSCObjectCache<T extends TSCV8Backed> implements Closeable
 
     public abstract T getOrCreate(TSCProgramContext programContext, V8ValueObject objectV8);
 
-    @Override
-    public abstract void close();
-
     /** Hide the `TKey` implementation detail within an Impl class. */
     private static class Impl<TKey, T extends TSCV8Backed> extends TSCObjectCache<T> {
-        private final V8Scope scope = new V8Scope();
         private final Map<TKey, T> cache = new HashMap<>();
         private final KeyProvider<TKey> getKey;
         private final InstanceConstructor<T> makeInstance;
@@ -64,19 +57,7 @@ public abstract class TSCObjectCache<T extends TSCV8Backed> implements Closeable
             try {
                 TKey key = getKey.getKey(programContext, objectV8);
                 return this.cache.computeIfAbsent(key, (_key) -> {
-                    V8ValueObject clone;
-                    try {
-                        // NOTE that this does not copy the JS object, i.e.
-                        //   const clone = {...objectV8}; // <-- NOT THIS
-                        // Instead, this is just copying the *reference*, i.e.
-                        //   const clone = objectV8;
-                        // We assume that `objectV8` will be closed by its caller.
-                        // So we clone it and associate it with this cache's V8Scope.
-                        clone = objectV8.toClone();
-                        scope.add(clone);
-                    } catch (JavetException e) {
-                        throw new RuntimeException(e);
-                    }
+                    V8ValueObject clone = lifecycleLinked(objectV8);
                     try {
                         return makeInstance.makeInstance(programContext, clone);
                     } catch (JavetException e) {
@@ -86,11 +67,6 @@ public abstract class TSCObjectCache<T extends TSCV8Backed> implements Closeable
             } catch (JavetException e) {
                 throw new RuntimeException(e);
             }
-        }
-
-        @Override
-        public void close() {
-            JavetResourceUtils.safeClose(scope);
         }
     }
 }

--- a/src/main/java/org/openrewrite/javascript/internal/tsc/TSCProgramContext.java
+++ b/src/main/java/org/openrewrite/javascript/internal/tsc/TSCProgramContext.java
@@ -16,49 +16,54 @@
 package org.openrewrite.javascript.internal.tsc;
 
 import com.caoccao.javet.exceptions.JavetException;
-import com.caoccao.javet.interop.V8Runtime;
-import com.caoccao.javet.interop.V8Scope;
-import com.caoccao.javet.utils.JavetResourceUtils;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.values.reference.V8ValueFunction;
 import com.caoccao.javet.values.reference.V8ValueObject;
 import lombok.Value;
 
 import javax.annotation.Nullable;
-import java.io.Closeable;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class TSCProgramContext implements Closeable {
-    private final V8Scope contextScope = new V8Scope();
-    private final V8Runtime runtime;
+public class TSCProgramContext extends TSCV8ValueHolder {
     private final V8ValueObject program;
-    private V8ValueObject typescriptV8;
-    private final V8ValueObject typeCheckerV8;
     private final V8ValueFunction createScanner;
     private final V8ValueFunction getOpenRewriteId;
 
-    /** In the virtual filesystem used by the compiler, this is the prefix for all input sources. */
+    /**
+     * In the virtual filesystem used by the compiler, this is the prefix for all input sources.
+     */
     private final Path compilerAppPath;
-    /** In the virtual filesystem used by the compiler, this is the prefix for all libs shipped with TS. */
+    /**
+     * In the virtual filesystem used by the compiler, this is the prefix for all libs shipped with TS.
+     */
     private final Path compilerLibPath;
 
-    private @Nullable TSCGlobals typescriptGlobals;
-    private @Nullable TSCTypeChecker typeChecker;
-    private @Nullable TSCInstanceOfChecks instanceOfChecks;
+    private TSCGlobals typescriptGlobals;
+    private TSCTypeChecker typeChecker;
+    private TSCInstanceOfChecks instanceOfChecks;
 
-    final TSCObjectCache<TSCNode> nodeCache = TSCObjectCache.usingInternalKey(TSCNode::wrap);
-    final TSCObjectCache<TSCType> typeCache = TSCObjectCache.usingPropertyAsKey("id", TSCType::new);
-    final TSCObjectCache<TSCSymbol> symbolCache = TSCObjectCache.usingInternalKey(TSCSymbol::new);
-    final TSCObjectCache<TSCSignature> signatureCache = TSCObjectCache.usingInternalKey(TSCSignature::new);
+    final TSCObjectCache<TSCNode> nodeCache = lifecycleLinked(TSCObjectCache.usingInternalKey(TSCNode::wrap));
+    final TSCObjectCache<TSCNodeList> nodeListCache = lifecycleLinked(TSCObjectCache.usingInternalKey(TSCNodeList::wrap));
+    final TSCObjectCache<TSCType> typeCache = lifecycleLinked(TSCObjectCache.usingPropertyAsKey("id", TSCType::new));
+    final TSCObjectCache<TSCSymbol> symbolCache = lifecycleLinked(TSCObjectCache.usingInternalKey(TSCSymbol::new));
+    final TSCObjectCache<TSCSignature> signatureCache = lifecycleLinked(TSCObjectCache.usingInternalKey(TSCSignature::new));
 
-    public TSCProgramContext(V8Runtime runtime, V8ValueObject program, V8ValueObject typescriptV8, V8ValueObject typeChecker, V8ValueFunction createScanner, V8ValueFunction getOpenRewriteId, Path compilerAppPath, Path compilerLibPath) {
-        this.runtime = runtime;
-        this.program = contextScope.add(program);
-        this.typescriptV8 = contextScope.add(typescriptV8);
-        this.typeCheckerV8 = contextScope.add(typeChecker);
-        this.createScanner = contextScope.add(createScanner);
-        this.getOpenRewriteId = contextScope.add(getOpenRewriteId);
+    public TSCProgramContext(
+            V8ValueObject program,
+            V8ValueObject tsGlobalsV8,
+            V8ValueObject typeCheckerV8,
+            V8ValueFunction createScanner,
+            V8ValueFunction getOpenRewriteId,
+            Path compilerAppPath,
+            Path compilerLibPath
+    ) {
+        this.program = lifecycleLinked(program);
+        this.typescriptGlobals = lifecycleLinked(TSCGlobals.fromJS(() -> this, tsGlobalsV8));
+        this.typeChecker = lifecycleLinked(TSCTypeChecker.fromJS(() -> this, typeCheckerV8));
+        this.instanceOfChecks = lifecycleLinked(TSCInstanceOfChecks.fromJS(tsGlobalsV8));
+        this.createScanner = lifecycleLinked(createScanner);
+        this.getOpenRewriteId = lifecycleLinked(getOpenRewriteId);
         this.compilerAppPath = compilerAppPath;
         this.compilerLibPath = compilerLibPath;
     }
@@ -66,19 +71,18 @@ public class TSCProgramContext implements Closeable {
     public static TSCProgramContext fromJS(V8ValueObject contextV8) {
         try (
                 V8ValueObject program = contextV8.get("program");
-                V8ValueObject typescript = contextV8.get("ts");
+                V8ValueObject tsGlobals = contextV8.get("ts");
                 V8ValueObject typeChecker = contextV8.get("typeChecker");
                 V8ValueFunction createScanner = contextV8.get("createScanner");
                 V8ValueFunction getOpenRewriteId = contextV8.get("getOpenRewriteId");
                 V8ValueObject pathPrefixes = contextV8.get("pathPrefixes");
         ) {
             return new TSCProgramContext(
-                    contextV8.getV8Runtime(),
-                    program.toClone(),
-                    typescript.toClone(),
-                    typeChecker.toClone(),
-                    createScanner.toClone(),
-                    getOpenRewriteId.toClone(),
+                    program,
+                    tsGlobals,
+                    typeChecker,
+                    createScanner,
+                    getOpenRewriteId,
                     Paths.get(pathPrefixes.getString("app")),
                     Paths.get(pathPrefixes.getString("lib"))
             );
@@ -97,23 +101,14 @@ public class TSCProgramContext implements Closeable {
 
 
     public TSCTypeChecker getTypeChecker() {
-        if (this.typeChecker == null) {
-            this.typeChecker = TSCTypeChecker.wrap(this, this.typeCheckerV8);
-        }
         return this.typeChecker;
     }
 
     public TSCGlobals getTypeScriptGlobals() {
-        if (this.typescriptGlobals == null) {
-            this.typescriptGlobals = TSCGlobals.wrap(this, this.typescriptV8);
-        }
         return this.typescriptGlobals;
     }
 
     public TSCInstanceOfChecks getInstanceOfChecks() {
-        if (this.instanceOfChecks == null) {
-            this.instanceOfChecks = TSCInstanceOfChecks.wrap(contextScope, getTypeScriptGlobals());
-        }
         return this.instanceOfChecks;
     }
 
@@ -137,6 +132,10 @@ public class TSCProgramContext implements Closeable {
         return this.nodeCache.getOrCreate(this, v8Value);
     }
 
+    public TSCNodeList tscNodeList(V8ValueObject v8Value) {
+        return this.nodeListCache.getOrCreate(this, v8Value);
+    }
+
     public TSCSymbol tscSymbol(V8ValueObject v8Value) {
         return this.symbolCache.getOrCreate(this, v8Value);
     }
@@ -145,7 +144,9 @@ public class TSCProgramContext implements Closeable {
         return this.signatureCache.getOrCreate(this, v8Value);
     }
 
-    /** This is *not* a concept in the TS compiler. This is part of the OpenRewrite-to-TSC bridge. */
+    /**
+     * This is *not* a concept in the TS compiler. This is part of the OpenRewrite-to-TSC bridge.
+     */
     public enum CompilerBridgeSourceKind {
         ApplicationCode,
         SystemLibrary,
@@ -171,15 +172,5 @@ public class TSCProgramContext implements Closeable {
             throw new IllegalArgumentException("unknown bridge source path (expected app or lib): " + rawPath);
         }
         return new CompilerBridgeSourceInfo(sourceKind, sourceKindRoot.relativize(rawPath));
-    }
-
-    @Override
-    public void close() {
-        JavetResourceUtils.safeClose(contextScope);
-        this.nodeCache.close();
-        this.typeCache.close();
-        this.symbolCache.close();
-        this.signatureCache.close();
-        this.typeChecker = null;
     }
 }

--- a/src/main/java/org/openrewrite/javascript/internal/tsc/TSCTypeChecker.java
+++ b/src/main/java/org/openrewrite/javascript/internal/tsc/TSCTypeChecker.java
@@ -23,23 +23,24 @@ import org.openrewrite.javascript.internal.tsc.generated.TSCTypeFlag;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.openrewrite.javascript.internal.tsc.TSCConversions.*;
 
-public class TSCTypeChecker implements TSCV8Backed {
+public class TSCTypeChecker extends TSCV8ValueHolder implements TSCV8Backed {
 
     // TODO: unmapped functions include all marked @internal and those that return "uncheckable" nodes
 
-    public static TSCTypeChecker wrap(TSCProgramContext context, V8ValueObject objectV8) {
+    public static TSCTypeChecker fromJS(Supplier<TSCProgramContext> context, V8ValueObject objectV8) {
         return new TSCTypeChecker(context, objectV8);
     }
 
-    private final TSCProgramContext programContext;
+    private final Supplier<TSCProgramContext> programContext;
     private final V8ValueObject objectV8;
 
-    private TSCTypeChecker(TSCProgramContext programContext, V8ValueObject objectV8) {
+    private TSCTypeChecker(Supplier<TSCProgramContext> programContext, V8ValueObject objectV8) {
         this.programContext = programContext;
-        this.objectV8 = objectV8;
+        this.objectV8 = lifecycleLinked(objectV8);
     }
 
     public TSCType getTypeOfSymbolAtLocation(TSCSymbol symbol, TSCNode node) {
@@ -333,7 +334,7 @@ public class TSCTypeChecker implements TSCV8Backed {
 
     @Override
     public TSCProgramContext getProgramContext() {
-        return programContext;
+        return programContext.get();
     }
 
     @Override

--- a/src/main/java/org/openrewrite/javascript/internal/tsc/TSCV8Backed.java
+++ b/src/main/java/org/openrewrite/javascript/internal/tsc/TSCV8Backed.java
@@ -23,9 +23,9 @@ import com.caoccao.javet.values.reference.V8ValueFunction;
 import com.caoccao.javet.values.reference.V8ValueObject;
 import lombok.Value;
 import org.openrewrite.DebugOnly;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.javascript.internal.tsc.generated.TSCSyntaxKind;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -137,7 +137,7 @@ public interface TSCV8Backed {
         return invokeMethodNonNull(name, BOOLEAN, args);
     }
 
-    default <T> T getPropertyNullable(String name, TSCConversion<T> conversion) {
+    default <T> @Nullable T getPropertyNullable(String name, TSCConversion<T> conversion) {
         try (V8Value value = getPropertyUnsafe(name)) {
             return conversion.convertNullable(getProgramContext(), value);
         } catch (JavetException e) {
@@ -161,7 +161,7 @@ public interface TSCV8Backed {
         return getPropertyNonNull(name, BOOLEAN);
     }
 
-    default Boolean getOptionalBooleanProperty(String name) {
+    default @Nullable Boolean getOptionalBooleanProperty(String name) {
         return getPropertyNullable(name, BOOLEAN);
     }
 
@@ -214,11 +214,11 @@ public interface TSCV8Backed {
         return getPropertyNullable(name, NODE);
     }
 
-    default TSCNodeList<TSCNode> getNodeListProperty(String name) {
+    default TSCNodeList getNodeListProperty(String name) {
         return getPropertyNonNull(name, NODE_LIST);
     }
 
-    default @Nullable TSCNodeList<TSCNode> getOptionalNodeListProperty(String name) {
+    default @Nullable TSCNodeList getOptionalNodeListProperty(String name) {
         return getPropertyNullable(name, NODE_LIST);
     }
 
@@ -226,7 +226,7 @@ public interface TSCV8Backed {
         return getPropertyNonNull(name, TYPE_NODE);
     }
 
-    default TSCNode.TypeNode getOptionalTypeNodeProperty(String name) {
+    default @Nullable TSCNode.TypeNode getOptionalTypeNodeProperty(String name) {
         return getPropertyNullable(name, TYPE_NODE);
     }
 

--- a/src/main/java/org/openrewrite/javascript/internal/tsc/TSCV8ValueHolder.java
+++ b/src/main/java/org/openrewrite/javascript/internal/tsc/TSCV8ValueHolder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.internal.tsc;
+
+import com.caoccao.javet.exceptions.JavetException;
+import com.caoccao.javet.values.IV8Value;
+import com.caoccao.javet.values.primitive.V8ValueNull;
+import com.caoccao.javet.values.primitive.V8ValuePrimitive;
+import com.caoccao.javet.values.primitive.V8ValueUndefined;
+import org.openrewrite.javascript.internal.JavetUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class TSCV8ValueHolder implements AutoCloseable {
+
+    private final List<IV8Value> v8Values = new ArrayList<>();
+    private final List<AutoCloseable> otherValues = new ArrayList<>();
+    private boolean isClosed = false;
+
+    protected <T extends AutoCloseable> T lifecycleLinked(T value) {
+        if (isClosed) {
+            throw new IllegalStateException("attempt to add value when already closed");
+        }
+
+        if (value instanceof V8ValuePrimitive || value instanceof V8ValueUndefined || value instanceof V8ValueNull) {
+            // primitives, null, and undefined aren't managed
+            return value;
+        }
+
+        if (value instanceof IV8Value) {
+            try {
+                //noinspection unchecked
+                value = (T) ((IV8Value) value).toClone();
+            } catch (JavetException e) {
+                throw new RuntimeException(e);
+            }
+            this.v8Values.add((IV8Value) value);
+        } else {
+            this.otherValues.add(value);
+        }
+
+        return value;
+    }
+
+    @Override
+    public final void close() {
+        if (this.isClosed) {
+            throw new IllegalStateException("already closed");
+        }
+        this.isClosed = true;
+
+        for (IV8Value valueV8 : v8Values) {
+            JavetUtils.close(valueV8);
+        }
+        for (AutoCloseable value : otherValues) {
+            try {
+                value.close();
+            } catch (Exception e) {
+                System.err.println("Exception while attempting to close a " + value.getClass().getName());
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/javascript/internal/V8InteropTests.java
+++ b/src/test/java/org/openrewrite/javascript/internal/V8InteropTests.java
@@ -401,5 +401,37 @@ public class V8InteropTests {
         );
     }
 
+    @Test
+    public void missingImportDoesNotThrow() {
+        parseSingleSource(
+                """
+                import * as doesNotExist from './does/not/exist';
+                                
+                function test() {
+                    return doesNotExist;
+                }
+                """,
+                "example.ts",
+                (root, ctx) -> {
+                }
+        );
+    }
+
+    @Test
+    public void missingDirectiveOrDirectiveDoesNotThrow() {
+        parseSingleSource(
+                """
+                /// <reference path='..\\..\\src\\compiler\\tsc.ts'/>
+                                
+                function test() {
+                    return 42;
+                }
+                """,
+                "example.ts",
+                (root, ctx) -> {
+                }
+        );
+    }
+
 
 }


### PR DESCRIPTION
- typescript wrapper JS
  - make VFS tracing configurable
- V8 interop
  - put lifecycle management into a base class for wrappers
  - don't lazy-initialize wrappers within the program context
  - don't use Java Map for passing named arguments to `makeFunction` (reference management behavior is unexpected)
  - don't scatter `toClone()` around
  - don't use default Javet `close()` utility
  - prefix both lib and application paths
  - fix bug with node list conversion
- parser
  - fix extension bug