### PR TITLE
Re-enabled gradle build cache.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,3 +2,40 @@ rootProject.name = "rewrite-javascript"
 include("js")
 
 enableFeaturePreview("VERSION_ORDERING_V2")
+
+plugins {
+    id("com.gradle.enterprise") version "latest.release"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "latest.release"
+}
+
+gradleEnterprise {
+    val isCiServer = System.getenv("CI")?.equals("true") ?: false
+    server = "https://ge.openrewrite.org/"
+    val gradleCacheRemoteUsername: String? = System.getenv("GRADLE_ENTERPRISE_CACHE_USERNAME")
+    val gradleCacheRemotePassword: String? = System.getenv("GRADLE_ENTERPRISE_CACHE_PASSWORD")
+
+    buildCache {
+        remote(HttpBuildCache::class) {
+            url = uri("https://ge.openrewrite.org/cache/")
+            isPush = isCiServer
+            if (!gradleCacheRemoteUsername.isNullOrBlank() && !gradleCacheRemotePassword.isNullOrBlank()) {
+                credentials {
+                    username = gradleCacheRemoteUsername
+                    password = gradleCacheRemotePassword
+                }
+            }
+        }
+    }
+
+    buildScan {
+        capture {
+            isTaskInputFiles = true
+        }
+
+        isUploadInBackground = !isCiServer
+
+        publishAlways()
+        this as com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
+        publishIfAuthenticated()
+    }
+}


### PR DESCRIPTION
We fixed a couple of issues that should allow caching to be re-enabled:

1. LSTs would not deserialze. Fixed by removing `lombok.anyConstructor.addConstructorProperties=true` from lombok.config.
2. The wrong snapshots were loaded via `latest.integration`. Released `0.3.0`.

fixes #41 