### PR TITLE
[WIP] Add support AsyncKeyword

### DIFF
--- a/src/main/java/org/openrewrite/javascript/TypeScriptTypeMapping.java
+++ b/src/main/java/org/openrewrite/javascript/TypeScriptTypeMapping.java
@@ -557,7 +557,8 @@ public class TypeScriptTypeMapping implements JavaTypeMapping<TSCNode> {
                     // TODO: get input from Gary ... is there any reason to add export as a modifier to the JavaType?
                     break;
                 default:
-                    if (modifier.syntaxKind() != TSCSyntaxKind.Decorator) {
+                    if (modifier.syntaxKind() != TSCSyntaxKind.Decorator &&
+                        modifier.syntaxKind() != TSCSyntaxKind.AsyncKeyword) {
                         // Decorators are handled separately to ensure the JavaType for a class is cached before type attributing annotations.
                         implementMe(modifier.syntaxKind());
                     }

--- a/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
+++ b/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
@@ -979,8 +979,19 @@ public class TypeScriptParserVisitor {
         implementMe(node, "typeArguments");
         implementMe(node, "type");
         Space prefix = whitespace();
-
         List<J.Annotation> annotations = new ArrayList<>();
+
+        TSCSyntaxKind keyword = scan();
+        if (keyword == TSCSyntaxKind.AsyncKeyword) {
+            annotations.add(new J.Annotation(
+                randomId(),
+                prefix,
+                Markers.build(singletonList(new Keyword(randomId()))),
+                convertToIdentifier(EMPTY, "async"),
+                null)
+            );
+        }
+
         List<J.Modifier> modifiers = mapModifiers(node.getOptionalNodeListProperty("modifiers"), annotations);
 
         Space before = sourceBefore(TSCSyntaxKind.FunctionKeyword);
@@ -2621,7 +2632,8 @@ public class TypeScriptParserVisitor {
                 // JS/TS keywords.
                 case DeclareKeyword:
                 case DefaultKeyword:
-                case ExportKeyword: {
+                case ExportKeyword:
+                case AsyncKeyword: {
                     annotations = mapKeywordToAnnotation(prefix, node, annotations);
                     break;
                 }
@@ -2629,11 +2641,6 @@ public class TypeScriptParserVisitor {
                 case AbstractKeyword:
                     consumeToken(TSCSyntaxKind.AbstractKeyword);
                     modifiers.add(new J.Modifier(randomId(), prefix, Markers.EMPTY, J.Modifier.Type.Abstract, annotations == null ? emptyList() : annotations));
-                    annotations = null;
-                    break;
-                case AsyncKeyword:
-                    consumeToken(TSCSyntaxKind.AsyncKeyword);
-                    modifiers.add(new J.Modifier(randomId(), prefix, Markers.EMPTY, J.Modifier.Type.Async, annotations == null ? emptyList() : annotations));
                     annotations = null;
                     break;
                 case PublicKeyword:

--- a/src/test/java/org/openrewrite/javascript/tree/MethodDeclarationTest.java
+++ b/src/test/java/org/openrewrite/javascript/tree/MethodDeclarationTest.java
@@ -87,4 +87,15 @@ public class MethodDeclarationTest extends ParserTest {
           )
         );
     }
+
+    @Test
+    void asyncKeyword() {
+        rewriteRun(
+          javaScript(
+            """
+              async function bar() {}
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Add support `AsyncKeyword`
However, got an error related to `TypeScriptParserVisitor#scan`, and haven't found a way to fix this.


given the code 
```typescript
async function bar() {}
```
to parse 

The issue is in this code snippet, 
```java
    private J.MethodDeclaration visitFunctionDeclaration(TSCNode node) {
        implementMe(node, "asteriskToken");
        implementMe(node, "typeParameters");
        implementMe(node, "typeArguments");
        implementMe(node, "type");
        Space prefix = whitespace();
        List<J.Annotation> annotations = new ArrayList<>();

        TSCSyntaxKind keyword = scan();           // Line 984
        if (keyword == TSCSyntaxKind.AsyncKeyword) {
            annotations.add(new J.Annotation(
                randomId(),
                prefix,
                Markers.build(singletonList(new Keyword(randomId()))),
                convertToIdentifier(EMPTY, "async"),
                null)
            );
        }

        List<J.Modifier> modifiers = mapModifiers(node.getOptionalNodeListProperty("modifiers"), annotations);    // Line 995

        Space before = sourceBefore(TSCSyntaxKind.FunctionKeyword);    // Line 997
        annotations = mapKeywordToAnnotation(before, "function", annotations);
```

Seems `TypeScriptParserVisitor#scan` is stateful, 
Line 984 called it once, and got `TSCSyntaxKind.AsyncKeyword)` (looks good so far) , the next scan will get a `TSCSyntaxKind.WhitespaceTrivia`, and then followed a `TSCSyntaxKind.FunctionKeyword`. 
However, in line 995, it invoked `whitespace() ` method which called `TypeScriptParserVisitor#scan` twice internally and skipped `TSCSyntaxKind.FunctionKeyword`, so line 997 can not consume `TSCSyntaxKind.FunctionKeyword`. 