### PR TITLE
Preserve order of inputs in TSCMapper.

### DIFF
--- a/src/main/java/org/openrewrite/javascript/internal/TSCMapper.java
+++ b/src/main/java/org/openrewrite/javascript/internal/TSCMapper.java
@@ -25,10 +25,7 @@ import org.openrewrite.tree.ParsingExecutionContextView;
 
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public abstract class TSCMapper implements AutoCloseable {
 
@@ -47,7 +44,7 @@ public abstract class TSCMapper implements AutoCloseable {
     private final Path relativeTo;
 
     private final ParsingExecutionContextView pctx;
-    private final Map<Path, SourceWrapper> sourcesByRelativePath = new HashMap<>();
+    private final Map<Path, SourceWrapper> sourcesByRelativePath = new LinkedHashMap<>();
 
     public TSCMapper(@Nullable Path relativeTo, ParsingExecutionContextView pctx) {
         JavetNativeBridge.init();
@@ -76,7 +73,7 @@ public abstract class TSCMapper implements AutoCloseable {
     public List<JS.CompilationUnit> build() {
         List<JS.CompilationUnit> compilationUnits = new ArrayList<>(sourcesByRelativePath.size());
 
-        Map<Path, String> sourceTextsForTSC = new HashMap<>();
+        Map<Path, String> sourceTextsForTSC = new LinkedHashMap<>();
         this.sourcesByRelativePath.forEach((relativePath, sourceText) -> {
             sourceTextsForTSC.put(relativePath, sourceText.sourceText);
         });

--- a/src/test/java/org/openrewrite/javascript/tree/ParserTest.java
+++ b/src/test/java/org/openrewrite/javascript/tree/ParserTest.java
@@ -16,11 +16,12 @@
 package org.openrewrite.javascript.tree;
 
 import org.intellij.lang.annotations.Language;
-import org.openrewrite.ParseExceptionResult;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
+import org.openrewrite.javascript.JavaScriptIsoVisitor;
 import org.openrewrite.javascript.JavaScriptParser;
 import org.openrewrite.javascript.JavaScriptVisitor;
 import org.openrewrite.test.RewriteTest;
@@ -38,8 +39,15 @@ public class ParserTest implements RewriteTest {
         });
     }
 
-    public static SourceSpecs javaScript(@Language("typescript") @Nullable String before, Consumer<SourceSpec<JS.CompilationUnit>> spec) {
-        SourceSpec<JS.CompilationUnit> js = new SourceSpec<>(JS.CompilationUnit.class, null, JavaScriptParser.builder(), before, null);
+    static void customizeExecutionContext(ExecutionContext ctx) {
+    }
+
+    public static SourceSpecs javaScript(@Language("typescript") @Nullable String before,
+                                         Consumer<SourceSpec<JS.CompilationUnit>> spec) {
+        SourceSpec<JS.CompilationUnit> js = new SourceSpec<>(
+                JS.CompilationUnit.class, null, JavaScriptParser.builder(), before,
+                SourceSpec.EachResult.noop,
+                ParserTest::customizeExecutionContext);
         acceptSpec(spec, js);
         return js;
     }
@@ -51,7 +59,10 @@ public class ParserTest implements RewriteTest {
 
     public static SourceSpecs javaScript(@Language("typescript") @Nullable String before, @Language("typescript") String after,
                                          Consumer<SourceSpec<JS.CompilationUnit>> spec) {
-        SourceSpec<JS.CompilationUnit> js = new SourceSpec<>(JS.CompilationUnit.class, null, JavaScriptParser.builder(), before, s -> after);
+        SourceSpec<JS.CompilationUnit> js = new SourceSpec<>(
+                JS.CompilationUnit.class, null, JavaScriptParser.builder(), before,
+                SourceSpec.EachResult.noop,
+                ParserTest::customizeExecutionContext).after(s -> after);
         acceptSpec(spec, js);
         return js;
     }
@@ -64,13 +75,14 @@ public class ParserTest implements RewriteTest {
 
     public static Consumer<SourceSpec<JS.CompilationUnit>> isFullyParsed() {
         return spec -> spec.afterRecipe(cu -> {
-            new JavaVisitor<Integer>() {
+            new JavaScriptIsoVisitor<Integer>() {
                 @Override
                 public Space visitSpace(Space space, Space.Location loc, Integer integer) {
                     assertThat(space.getWhitespace().trim()).isEmpty();
                     return super.visitSpace(space, loc, integer);
                 }
             }.visit(cu, 0);
+
             new JavaScriptVisitor<Integer>() {
                 @Override
                 public @Nullable J preVisit(J tree, Integer integer) {
@@ -82,5 +94,15 @@ public class ParserTest implements RewriteTest {
                 }
             }.visit(cu, 0);
         });
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-javascript/issues/57")
+    @Test
+    void preservesOrder() {
+        rewriteRun(
+          javaScript("class A {}", s -> s.path("A.js")),
+          javaScript("class B {}", s -> s.path("B.js")),
+          javaScript("class C {}", s -> s.path("C.js"))
+        );
     }
 }


### PR DESCRIPTION
The TSCMapper uses a map to collect the ParserInputs, which randomizes the order and causes multiple problems.
Ideally, we'll use the input list and parse the files, but there isn't time to refactor the TSCMapper.
For now, I added a `LinkedHashMap` to return the JS.CUs in the same order as the source files.

fixes #57
