### PR TITLE
Exclude Yarn Plug'n'Play files

### DIFF
--- a/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
+++ b/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
@@ -79,6 +79,11 @@ public class JavaScriptParser implements Parser {
             ".ts", ".tsx", ".mts", ".cts"
     ));
 
+    // Exclude Yarn's Plug'n'Play loader files (https://yarnpkg.com/features/pnp)
+    private final static List<String> EXCLUSIONS = Collections.unmodifiableList(Arrays.asList(
+            ".pnp.cjs", ".pnp.loader.mjs"
+    ));
+
     @Override
     public boolean accept(Path path) {
         if (path.toString().contains("/dist/")) {
@@ -88,7 +93,7 @@ public class JavaScriptParser implements Parser {
 
         final String filename = path.getFileName().toString().toLowerCase();
         for (String ext : EXTENSIONS) {
-            if (filename.endsWith(ext)) {
+            if (filename.endsWith(ext) && !EXCLUSIONS.contains(filename)) {
                 return true;
             }
         }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Exclude Yarn Plug'n'Play files from parsing (https://yarnpkg.com/features/pnp)

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Reduce the parsing time of large projects

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
