### PR TITLE
Minor update to JavaScriptParser to generate correct AST elements.

### DIFF
--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -3,9 +3,9 @@
   "display": "Node 14",
 
   "compilerOptions": {
-    "lib": ["es2020"],
+    "lib": ["esnext"],
     "module": "commonjs",
-    "target": "es2020",
+    "target": "esnext",
     "resolveJsonModule": true,
     "strict": true,
     "esModuleInterop": true,

--- a/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
+++ b/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
@@ -102,7 +102,7 @@ public class JavaScriptParser implements Parser {
 
     @Override
     public Path sourcePathFromSourceText(Path prefix, String sourceCode) {
-        return prefix.resolve("file.js");
+        return prefix.resolve("file.ts");
     }
 
     public static Builder builder() {

--- a/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
+++ b/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
@@ -16,12 +16,14 @@
 package org.openrewrite.javascript.internal;
 
 import org.openrewrite.FileAttributes;
+import org.openrewrite.ParseExceptionResult;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.JavaTypeCache;
 import org.openrewrite.java.marker.Semicolon;
 import org.openrewrite.java.marker.TrailingComma;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.javascript.JavaScriptParser;
 import org.openrewrite.javascript.TypeScriptTypeMapping;
 import org.openrewrite.javascript.internal.tsc.TSCNode;
 import org.openrewrite.javascript.internal.tsc.TSCNodeList;
@@ -78,6 +80,8 @@ public class TypeScriptParserVisitor {
                 Space childPrefix = whitespace();
                 String text = child.getText();
                 skip(text);
+                Markers childMarkers = Markers.build(singletonList(ParseExceptionResult.build(JavaScriptParser.builder().build(), t)
+                        .withTreeType(child.syntaxKind().name())));
                 visited = new J.Unknown(
                         randomId(),
                         childPrefix,
@@ -85,7 +89,7 @@ public class TypeScriptParserVisitor {
                         new J.Unknown.Source(
                                 randomId(),
                                 EMPTY,
-                                Markers.EMPTY,
+                                childMarkers,
                                 text));
             }
 
@@ -3164,7 +3168,8 @@ public class TypeScriptParserVisitor {
                         new J.Unknown.Source(
                                 randomId(),
                                 EMPTY,
-                                Markers.EMPTY,
+                                Markers.build(singletonList(ParseExceptionResult.build(JavaScriptParser.builder().build(), e)
+                                        .withTreeType(element.syntaxKind().name()))),
                                 text));
             }
             Space after = i == elements.size() - 1 ? suffix.apply(element) : innerSuffix.apply(element);
@@ -3247,7 +3252,8 @@ public class TypeScriptParserVisitor {
                                 new J.Unknown.Source(
                                         randomId(),
                                         EMPTY,
-                                        Markers.EMPTY,
+                                        Markers.build(singletonList(ParseExceptionResult.build(JavaScriptParser.builder().build(), e)
+                                                .withTreeType(node.syntaxKind().name()))),
                                         text));
                     } else {
                         throw e;
@@ -3503,7 +3509,8 @@ public class TypeScriptParserVisitor {
                 new J.Unknown.Source(
                         randomId(),
                         EMPTY,
-                        Markers.EMPTY,
+                        Markers.build(singletonList(ParseExceptionResult.build(JavaScriptParser.builder().build(), new UnsupportedOperationException(node.syntaxKind().name() + " not implemented"))
+                                .withTreeType(node.syntaxKind().name()))),
                         text));
     }
 

--- a/src/test/java/org/openrewrite/javascript/tree/MethodInvocationTest.java
+++ b/src/test/java/org/openrewrite/javascript/tree/MethodInvocationTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.javascript.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 
 @SuppressWarnings("JSUnusedLocalSymbols")
 class MethodInvocationTest extends ParserTest {
@@ -45,6 +46,7 @@ class MethodInvocationTest extends ParserTest {
         );
     }
 
+    @ExpectedToFail("Requires CallExpression#typeArguments")
     @Test
     void typeArguments() {
         rewriteRun(


### PR DESCRIPTION
Changes:
- JavaScriptParser creates test files with `.ts` extension instead of `.js`
- Updated `ts.config` to match the script target in the runtime `index.ts` in`createScanner()`
- Updated tests to fail when ParserErrors are detected in the source.

fixes #56 
