### PR TITLE
Preserve leading comments.

### DIFF
--- a/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
+++ b/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
@@ -3069,7 +3069,9 @@ public class TypeScriptParserVisitor {
      * Consume the provided text if it matches the current cursor position.
      */
     private void skip(String text) {
-        if (source.getText().startsWith(text, getCursor())) {
+        if (source.hasProperty("text") && source.getStringProperty("text").startsWith(text, getCursor())) {
+            cursor(getCursor() + text.length());
+        } else if (source.getText().startsWith(text, getCursor())) {
             cursor(getCursor() + text.length());
         }
     }

--- a/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
+++ b/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
@@ -103,10 +103,9 @@ public class TypeScriptParserVisitor {
 
         Space eof = whitespace();
         String remainingWhitespace = "";
-        if (source.hasProperty("text") && getCursor() < source.getStringProperty("text").length()) {
-            remainingWhitespace = source.getStringProperty("text").substring(getCursor());
-        } else if (getCursor() < source.getText().length()) {
-            remainingWhitespace = source.getText().substring(getCursor());
+        String sourceText = source.getStringProperty("text");
+        if (getCursor() < sourceText.length()) {
+            remainingWhitespace = sourceText.substring(getCursor());
         }
 
         eof = eof.withWhitespace(eof.getWhitespace() + remainingWhitespace);

--- a/src/main/java/org/openrewrite/javascript/internal/tsc/TSCRuntime.java
+++ b/src/main/java/org/openrewrite/javascript/internal/tsc/TSCRuntime.java
@@ -163,7 +163,7 @@ public class TSCRuntime implements AutoCloseable {
                     }
 
                     V8ValueObject sourceFileV8 = (V8ValueObject) maybeSourceFileV8;
-                    String sourceText = sourceFileV8.invokeString("getText");
+                    String sourceText = sourceFileV8.getPropertyString("text");
                     Path filePath = Paths.get(filePathV8.getValue());
                     try (TSCSourceFileContext sourceFileContext = new TSCSourceFileContext(programContext, sourceText, filePath)) {
                         TSCNode node = programContext.tscNode(sourceFileV8);

--- a/src/test/java/org/openrewrite/javascript/tree/CommentTest.java
+++ b/src/test/java/org/openrewrite/javascript/tree/CommentTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.javascript.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 
 @SuppressWarnings("JSUnusedLocalSymbols")
 class CommentTest extends ParserTest {
@@ -100,7 +99,6 @@ class CommentTest extends ParserTest {
         );
     }
 
-    @ExpectedToFail
     @Test
     void leadingComment() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/javascript/tree/ParserPerfTest.java
+++ b/src/test/java/org/openrewrite/javascript/tree/ParserPerfTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.javascript.tree;
 
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.test.RewriteTest;
 
@@ -27,7 +26,6 @@ class ParserPerfTest implements RewriteTest {
     @Language("typescript")
     private static final String cometd = StringUtils.readFully(ParserPerfTest.class.getResourceAsStream("/perf/cometd.js"));
 
-    @ExpectedToFail("Requires issue https://github.com/openrewrite/rewrite-javascript/issues/4 to pass parsing.")
     @Test
     void tryParseCometd() {
         rewriteRun(ParserTest.javaScript(cometd));


### PR DESCRIPTION
Changes:
- Source text used to generate the `sourceFileContext` includes leading comments.
- Added `sourceStartsWithAtCursor` and updated methods that check if the source starts with text at the cursor to use `sourceStartsWithAtCursor`.

Notes:
Previously, the `sourceFileContext` did not include leading comments because `sourceFileV8.invokeString("getText")` does not include the leading comments. The `text` property consists of the leading comments, allowing the scanner to detect the `Trivial` tokens.

fixes #4