### PR TITLE
Support `keyof` keyword

### DIFF
--- a/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
+++ b/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
@@ -338,7 +338,7 @@ public class JavaScriptPrinter<P> extends JavaScriptVisitor<PrintOutputCapture<P
         String keyword = "";
         if (typeOperator.getOperator() == JS.TypeOperator.Type.ReadOnly) {
             keyword = "readonly";
-        } else if (typeOperator.getOperator() == JS.TypeOperator.Type.Keyof) {
+        } else if (typeOperator.getOperator() == JS.TypeOperator.Type.KeyOf) {
             keyword = "keyof";
         }
 

--- a/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
+++ b/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
@@ -338,6 +338,8 @@ public class JavaScriptPrinter<P> extends JavaScriptVisitor<PrintOutputCapture<P
         String keyword = "";
         if (typeOperator.getOperator() == JS.TypeOperator.Type.ReadOnly) {
             keyword = "readonly";
+        } else if (typeOperator.getOperator() == JS.TypeOperator.Type.Keyof) {
+            keyword = "keyof";
         }
 
         p.append(keyword);

--- a/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
+++ b/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
@@ -2333,6 +2333,9 @@ public class TypeScriptParserVisitor {
         if (op == TSCSyntaxKind.ReadonlyKeyword) {
             before = sourceBefore(TSCSyntaxKind.ReadonlyKeyword);
             operator = JS.TypeOperator.Type.ReadOnly;
+        } else if (op == TSCSyntaxKind.KeyOfKeyword) {
+            before = sourceBefore(TSCSyntaxKind.KeyOfKeyword);
+            operator = JS.TypeOperator.Type.Keyof;
         } else {
             implementMe(node);
         }

--- a/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
+++ b/src/main/java/org/openrewrite/javascript/internal/TypeScriptParserVisitor.java
@@ -2335,7 +2335,7 @@ public class TypeScriptParserVisitor {
             operator = JS.TypeOperator.Type.ReadOnly;
         } else if (op == TSCSyntaxKind.KeyOfKeyword) {
             before = sourceBefore(TSCSyntaxKind.KeyOfKeyword);
-            operator = JS.TypeOperator.Type.Keyof;
+            operator = JS.TypeOperator.Type.KeyOf;
         } else {
             implementMe(node);
         }

--- a/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -1679,7 +1679,7 @@ public interface JS extends J {
 
         public enum Type {
             ReadOnly,
-            Keyof,
+            KeyOf,
         }
 
         public JS.TypeOperator.Padding getPadding() {

--- a/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -1678,7 +1678,8 @@ public interface JS extends J {
         }
 
         public enum Type {
-            ReadOnly
+            ReadOnly,
+            Keyof,
         }
 
         public JS.TypeOperator.Padding getPadding() {

--- a/src/test/java/org/openrewrite/javascript/tree/UnaryTest.java
+++ b/src/test/java/org/openrewrite/javascript/tree/UnaryTest.java
@@ -60,20 +60,17 @@ class UnaryTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail
     @Test
     void keyofKeyword() {
         rewriteRun(
           javaScript(
             """
-              type Person = { name: string; age: number };
+              type Person = { name: string , age: number };
               type KeysOfPerson = keyof Person;
-              let person: Person = {
-                  name: "John",
-                  age: 42,
-                };
               """
           )
         );
     }
+
+
 }


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-javascript/issues/90

currently, we have a model `TypeOperator` for type-operator, but I think it may be better to use a `Unary` to present type-operator since it's more generic.