### PR TITLE
Adopt Javet latest.release to pick up 3.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,8 +21,8 @@ dependencies {
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
 
-    implementation("com.caoccao.javet:javet-macos:3.0.0") // Mac OS (x86_64 and arm64)
-    implementation("com.caoccao.javet:javet:3.0.0") // Linux and Windows
+    implementation("com.caoccao.javet:javet-macos:latest.release") // Mac OS (x86_64 and arm64)
+    implementation("com.caoccao.javet:javet:latest.release") // Linux and Windows
 }
 
 tasks.withType<Javadoc> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:latest.release")
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite.recipe:rewrite-static-analysis:${latest}")
-    testImplementation("org.junit-pioneer:junit-pioneer:2.0.0")
+    testImplementation("org.junit-pioneer:junit-pioneer:latest.release")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
 


### PR DESCRIPTION
## What's changed?
Switch from an explicit 3.0.0 to `latest.release`, as we do for other dependencies.

## What's your motivation?
Today that picks up v3.0.2 as per https://github.com/caoccao/Javet/releases
Going forward we'll pick up newer versions automatically, as 

## Anything in particular you'd like reviewers to focus on?
Was there any reason we pinned to 3.0.0 explicitly? Any reason not to use latest?

## Have you considered any alternatives or workarounds?
We could use a newer explicit version and periodically bump through PRs.
Could prevent breakage on main, but still needs attention to resolve then.
