### PR TITLE
Implemented qualifiedName visitor

### DIFF
--- a/openrewrite/src/javascript/parser.ts
+++ b/openrewrite/src/javascript/parser.ts
@@ -532,7 +532,14 @@ export class JavaScriptParserVisitor {
     }
 
     visitQualifiedName(node: ts.QualifiedName) {
-        return this.visitUnknown(node);
+        return new J.FieldAccess(
+            randomId(),
+            this.prefix(node),
+            Markers.EMPTY,
+            this.visit(node.left),
+            new JLeftPadded<J.Identifier>(this.suffix(node.left), this.convert<J.Identifier>(node.right), Markers.EMPTY),
+            this.mapType(node)
+        );
     }
 
     visitComputedPropertyName(node: ts.ComputedPropertyName) {

--- a/openrewrite/src/javascript/parser.ts
+++ b/openrewrite/src/javascript/parser.ts
@@ -42,7 +42,7 @@ export class JavaScriptParser extends Parser {
         const result: SourceFile[] = [];
         for (const filePath of program.getRootFileNames()) {
             const sourceFile = program.getSourceFile(filePath)!;
-            const input = new ParserInput(filePath, null, false, () =>  Buffer.from(ts.sys.readFile(filePath)!));
+            const input = new ParserInput(filePath, null, false, () => Buffer.from(ts.sys.readFile(filePath)!));
             try {
                 const parsed = new JavaScriptParserVisitor(this, sourceFile, typeChecker).visit(sourceFile) as SourceFile;
                 result.push(parsed);
@@ -532,7 +532,7 @@ export class JavaScriptParserVisitor {
     }
 
     visitQualifiedName(node: ts.QualifiedName) {
-        return new J.FieldAccess(
+        const fieldAccess = new J.FieldAccess(
             randomId(),
             this.prefix(node),
             Markers.EMPTY,
@@ -540,6 +540,20 @@ export class JavaScriptParserVisitor {
             new JLeftPadded<J.Identifier>(this.suffix(node.left), this.convert<J.Identifier>(node.right), Markers.EMPTY),
             this.mapType(node)
         );
+
+        const parent = node.parent as ts.TypeReferenceNode;
+        if (parent.typeArguments) {
+            return new J.ParameterizedType(
+                randomId(),
+                this.prefix(parent),
+                Markers.EMPTY,
+                fieldAccess,
+                this.mapTypeArguments(parent.typeArguments),
+                this.mapType(parent)
+            )
+        } else {
+            return fieldAccess;
+        }
     }
 
     visitComputedPropertyName(node: ts.ComputedPropertyName) {
@@ -688,6 +702,10 @@ export class JavaScriptParserVisitor {
 
     visitTypeReference(node: ts.TypeReferenceNode) {
         if (node.typeArguments) {
+            // Temporary check for supported constructions with type arguments
+            if (ts.isQualifiedName(node.typeName)) {
+                return this.visit(node.typeName);
+            }
             return this.visitUnknown(node);
         }
         return this.visit(node.typeName);
@@ -831,7 +849,7 @@ export class JavaScriptParserVisitor {
         const statements: JRightPadded<J.Statement>[] = this.rightPaddedSeparatedList(
             [...statementList.getChildren(this.sourceFile)],
             ts.SyntaxKind.CommaToken,
-            (nodes, i) => i == nodes.length -2 && nodes[i + 1].kind == ts.SyntaxKind.CommaToken ? Markers.build([new TrailingComma(randomId(), this.prefix(nodes[i + 1]))]) : Markers.EMPTY
+            (nodes, i) => i == nodes.length - 2 && nodes[i + 1].kind == ts.SyntaxKind.CommaToken ? Markers.build([new TrailingComma(randomId(), this.prefix(nodes[i + 1]))]) : Markers.EMPTY
         );
 
         return new J.Block(
@@ -1927,6 +1945,24 @@ export class JavaScriptParserVisitor {
 
     private mapCommaSeparatedList(nodes: readonly ts.Node[]): JContainer<J.Expression> {
         return this.mapToContainer(nodes, this.trailingComma(nodes));
+    }
+
+    private mapTypeArguments(nodes: readonly ts.Node[]): JContainer<J.Expression> {
+        if (nodes.length === 0) {
+            return JContainer.empty();
+        }
+
+        const args = nodes.map(node =>
+            this.rightPadded(
+                this.visit(node),
+                this.suffix(node),
+                Markers.EMPTY
+            ))
+        return new JContainer(
+            this.prefix(nodes[0]),
+            args,
+            Markers.EMPTY
+        );
     }
 
     private trailingComma = (nodes: readonly ts.Node[]) => (ns: readonly ts.Node[], i: number) => {

--- a/openrewrite/test/javascript/parser/qualifiedName.test.ts
+++ b/openrewrite/test/javascript/parser/qualifiedName.test.ts
@@ -1,0 +1,50 @@
+import {connect, disconnect, rewriteRun, typeScript} from '../testHarness';
+
+describe('empty mapping', () => {
+    beforeAll(() => connect());
+    afterAll(() => disconnect());
+
+    test('globalThis qualified name', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript('const value: globalThis.Number = 1')
+        );
+    });
+
+    test.skip('nested class qualified name', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              class OuterClass {
+                public static InnerClass = class extends Number { };
+              }
+              const a: typeof OuterClass.InnerClass.prototype = 1;
+          `)
+        );
+    });
+
+    test.skip('namespace qualified name', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              namespace TestNamespace { 
+                export class Test {} 
+              };
+              const value: TestNamespace.Test = null;
+          `)
+        );
+    });
+
+    test.skip('enum qualified name', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              enum Test {
+                  A
+              };
+
+              const val: Test.A = Test.A;
+          `)
+        );
+    });
+});

--- a/openrewrite/test/javascript/parser/qualifiedName.test.ts
+++ b/openrewrite/test/javascript/parser/qualifiedName.test.ts
@@ -11,6 +11,20 @@ describe('empty mapping', () => {
         );
     });
 
+    test('globalThis qualified name with generic', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript('const value: globalThis.Promise< string > = null')
+        );
+    });
+
+    test('globalThis qualified name with comments', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript('const value /*a123*/ : globalThis. globalThis . /*asda*/ globalThis.Promise<string> = null;')
+        );
+    });
+
     test.skip('nested class qualified name', () => {
         rewriteRun(
           //language=typescript


### PR DESCRIPTION
Most of the tests are skipped because enum, class, namespace constructions not supported yet.

Also modified testHarness runner to be able to join to remotely running rewrite-remote test engine

