### PR TITLE
Reworked classDeclaration visitor

### DIFF
--- a/openrewrite/test/javascript/parser/class.test.ts
+++ b/openrewrite/test/javascript/parser/class.test.ts
@@ -65,4 +65,118 @@ describe('class mapping', () => {
           typeScript('export default class A {}')
         );
     });
+
+    test('class with properties', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+                class X {
+                    a = 5
+                    b = 6
+                }
+          `)
+        );
+    });
+
+    test('class with properties and semicolon', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+               class X {
+                  a = 5;
+                  b = 6;
+              } /*asdasdas*/
+              //asdasf
+          `)
+        );
+    });
+
+    test('class with mixed properties with semicolons', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              class X {
+
+                  b = 6
+                  c = 10;
+                  a /*asdasd*/ =  /*abc*/   5
+                  d = "d";
+
+              } /*asdasdas*/
+              //asdasf
+          `)
+        );
+    });
+
+    test('class with properties, semicolon, methods, comments', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+                class X {
+                    a /*asdasd*/ =  /*abc*/   5;
+                    b = 6;
+
+                    // method 1
+                    abs(): string{
+                        return "1";
+                    }
+
+                    //method 2
+                    max(): number {
+                        return 2;
+                    }
+                } /*asdasdas*/ 
+                //asdasf
+          `)
+        );
+    });
+
+    test('class with several typed properties', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+                class X {
+                   
+                    b: number = 6
+                    c: string = "abc";
+                    a /*asdasd*/ =  /*abc*/   5
+                    
+                } /*asdasdas*/ 
+                //asdasf
+          `)
+        );
+    });
+
+    test('class with reference-typed property', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              class X {
+
+                  a: globalThis.Promise<string> = null;
+                  b: number = 6;
+                  c /*asdasd*/ =  /*abc*/   5
+
+              } /*asdasdas*/
+              //asdasf
+          `)
+        );
+    });
+
+    test('class with typed properties, modifiers, comments', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              class X /*abc*/ {
+                  public name   /*asdasda*/    :  /*dasdasda*/   string;
+                  private surname   /*asdasda*/    :  /*dasdasda*/   string =  "abc";
+                  b: number /* abc */ = 6;
+                  c = 10;
+                  a /*asdasd*/ =  /*abc*/   5
+                 
+              }
+              //asdasf
+          `)
+        );
+    });
 });

--- a/openrewrite/test/javascript/parser/variableDeclarations.test.ts
+++ b/openrewrite/test/javascript/parser/variableDeclarations.test.ts
@@ -63,7 +63,7 @@ describe('variable declaration mapping', () => {
     test('multi typed', () => {
         rewriteRun(
           //language=typescript
-          typeScript('let a: number =2, b: string = "2" ')
+          typeScript('  /*0.1*/  let  /*0.2*/    a   /*1*/ :      /*2*/  number =2    /*3*/ , /*4*/   b   /*5*/:/*6*/    /*7*/string  /*8*/   =/*9*/    "2" /*10*/  ; //11')
         );
     });
 });

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
@@ -769,7 +769,6 @@ public class JavaScriptPrinter<P> extends JavaScriptVisitor<PrintOutputCapture<P
 
                 visitSpace(variable.getAfter(), Space.Location.NAMED_VARIABLE_SUFFIX, p);
                 if (multiVariable.getTypeExpression() != null) {
-                    p.append(":");
                     visit(multiVariable.getTypeExpression(), p);
                 }
 


### PR DESCRIPTION
The `visitClassDeclaration` method has been rewritten to be able to parse classes with several declared properties correctly.

Example:
```
class X {
    a: number = 6;
    b: string = "abc";
    c /*asdasd*/ =  /*abc*/   5
}
```


