### PR TITLE
Implemented Enum declaration support

### DIFF
--- a/openrewrite/test/javascript/parser/enum.test.ts
+++ b/openrewrite/test/javascript/parser/enum.test.ts
@@ -1,0 +1,169 @@
+import {connect, disconnect, rewriteRun, typeScript} from '../testHarness';
+
+describe('empty mapping', () => {
+    beforeAll(() => connect());
+    afterAll(() => disconnect());
+
+    test('enum declaration', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              enum Test {
+              };
+          `)
+        );
+    });
+
+    test('enum empty declaration with modifiers', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              declare const enum Test {
+              };
+          `)
+        );
+    });
+
+    test('enum member', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              enum Test {
+                A
+              };
+          `)
+        );
+    });
+
+    test('enum member with coma', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              enum Test {
+                  A ,
+              };
+          `)
+        );
+    });
+
+    test('enum members', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              enum Test {
+                  A,
+                  B,
+                  C
+              };
+          `)
+        );
+    });
+
+    test('enum with const modifier', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              const enum Test {
+                  A,
+                  B,
+                  C,
+              };
+          `)
+        );
+    });
+
+    test('enum with declare modifier', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              declare enum Test {
+                  A,
+                  B,
+                  C,
+              };
+          `)
+        );
+    });
+
+    test('enum with declare const modifier', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              declare const enum Test {
+                  A,
+                  B,
+                  C,
+              };
+          `)
+        );
+    });
+
+    test('enum members with comments', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+               enum Test /*xx*/ {
+                  A /*aa*/,
+                  /*bb*/ B /*cc*/, 
+                  C, /*dd*/
+              };
+          `)
+        );
+    });
+
+    test('enum members with initializer', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              enum Test {
+                  A  = "AA",
+                  B = 10
+              }
+          `)
+        );
+    });
+
+    test('enum mixed members with initializer', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              enum Test {
+                  A  = "AA",
+                  B,
+                  C = 10,
+                  D = globalThis.NaN,
+                  E = (2 + 2),
+                  F,
+              }
+          `)
+        );
+    });
+
+    test('enum members with initializer and comments', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              enum Test {
+                  //A /*aaa*/ = /*bbb*/ "A"
+                  A  /*aaa*/  = /*bbb*/ "AA"  ,
+                  B = 10 /*ccc*/ + /*ddd*/ 5
+              }
+          `)
+        );
+    });
+
+    test('enum complex members with initializer', () => {
+        rewriteRun(
+          //language=typescript
+          typeScript(`
+              const baseValue = 10;
+
+              const enum MathConstants {
+                  Pi = 3.14,
+                  E = Math.E,
+                  GoldenRatio = baseValue + 1.618,
+              }
+          `)
+        );
+    });
+});

--- a/openrewrite/test/javascript/parser/qualifiedName.test.ts
+++ b/openrewrite/test/javascript/parser/qualifiedName.test.ts
@@ -49,12 +49,12 @@ describe('empty mapping', () => {
         );
     });
 
-    test.skip('enum qualified name', () => {
+    test('enum qualified name', () => {
         rewriteRun(
           //language=typescript
           typeScript(`
               enum Test {
-                  A
+                  A, B
               };
 
               const val: Test.A = Test.A;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
@@ -457,9 +457,10 @@ public class JavaScriptPrinter<P> extends JavaScriptVisitor<PrintOutputCapture<P
             J.NewClass initializer = enum_.getInitializer();
             if (initializer != null) {
                 visitSpace(initializer.getPrefix(), Space.Location.NEW_CLASS_PREFIX, p);
+                p.append("=");
                 // there can be only one argument
                 Expression expression = initializer.getArguments().get(0);
-                visitLeftPadded("=", JLeftPadded.build(expression), JLeftPadded.Location.VARIABLE_INITIALIZER, p);
+                visit(expression, p);
                 return enum_;
             }
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/JavaScriptPrinter.java
@@ -450,6 +450,24 @@ public class JavaScriptPrinter<P> extends JavaScriptVisitor<PrintOutputCapture<P
         }
 
         @Override
+        public J visitEnumValue(J.EnumValue enum_, PrintOutputCapture<P> p) {
+            beforeSyntax(enum_, Space.Location.ENUM_VALUE_PREFIX, p);
+            visit(enum_.getName(), p);
+
+            J.NewClass initializer = enum_.getInitializer();
+            if (initializer != null) {
+                visitSpace(initializer.getPrefix(), Space.Location.NEW_CLASS_PREFIX, p);
+                // there can be only one argument
+                Expression expression = initializer.getArguments().get(0);
+                visitLeftPadded("=", JLeftPadded.build(expression), JLeftPadded.Location.VARIABLE_INITIALIZER, p);
+                return enum_;
+            }
+
+            afterSyntax(enum_, p);
+            return enum_;
+        }
+
+        @Override
         public J visitAnnotation(J.Annotation annotation, PrintOutputCapture<P> p) {
             beforeSyntax(annotation, Space.Location.ANNOTATION_PREFIX, p);
             if (!annotation.getMarkers().findFirst(Keyword.class).isPresent()) {


### PR DESCRIPTION
Implemented `visitEnumDeclaration` parser.
To implement Enum members' initialisation, had to override the `visitEnumValue` method at `JavaScriptPrinter` class.

