### PR TITLE
Implemented support for ClassExpression

### DIFF
--- a/openrewrite/test/javascript/parser/arrow.test.ts
+++ b/openrewrite/test/javascript/parser/arrow.test.ts
@@ -13,6 +13,15 @@ describe('arrow mapping', () => {
         );
     });
 
+    test('function with empty body', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                const empty = (/*a*/) /*b*/ => {/*c*/};
+            `)
+        );
+    });
+
     test('function with simple body and comments', () => {
         rewriteRun(
           //language=typescript
@@ -48,6 +57,53 @@ describe('arrow mapping', () => {
           typeScript(`
               let sum = (x: number, y: number) => x + y;
           `)
+        );
+    });
+
+    test('function with trailing comma', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                let sum = (x: number, y: number /*a*/, /*b*/) => x + y;
+            `)
+        );
+    });
+
+    test('function with async modifier', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                let sum = async (x: number, y: number ) => x + y;
+            `)
+        );
+    });
+
+    test('basic async arrow function', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                const fetchData = async (): Promise<string> => {
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve("Data fetched successfully!");
+                        }, 2000);
+                    });
+                };
+
+                // Using the function
+                fetchData().then((message) => {
+                    console.log(message); // Outputs: Data fetched successfully! (after 2 seconds)
+                });
+            `)
+        );
+    });
+
+    test('function with async modifier and comments', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                let sum = /*a*/async /*b*/ (/*c*/x: number, y: number /*d*/) /*e*/ => x + y;
+            `)
         );
     });
 

--- a/openrewrite/test/javascript/parser/class.test.ts
+++ b/openrewrite/test/javascript/parser/class.test.ts
@@ -116,12 +116,12 @@ describe('class mapping', () => {
                     b = 6;
 
                     // method 1
-                    abs(): string{
+                    abs(x): string{
                         return "1";
                     }
 
                     //method 2
-                    max(): number {
+                    max(x, y /*a*/, /*b*/): number {
                         return 2;
                     }
                 } /*asdasdas*/
@@ -179,7 +179,6 @@ describe('class mapping', () => {
         );
     });
 
-
     test('class with simple ctor', () => {
         rewriteRun(
           //language=typescript
@@ -220,7 +219,70 @@ describe('class mapping', () => {
         );
     });
 
-    test.skip('anonymous class declaration', () => {
+    test('anonymous class expression', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                const MyClass = class {
+                    constructor(public name: string) {
+                    }
+                };
+            `)
+        );
+    });
+
+    test('anonymous class expression with comments', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                const MyClass = /*a*/class/*b*/ {/*c*/
+                    constructor(public name: string) {
+                    }
+                };
+            `)
+        );
+    });
+
+    test('named class expression', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                const Employee = class EmployeeClass {
+                    constructor(public position: string, public salary: number, ) {
+                    }
+                };
+            `)
+        );
+    });
+
+    test('class extends expression', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                class OuterClass extends (class extends Number { }) {
+                }
+            `)
+        );
+    });
+
+    test.skip('class expressions inline', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                function createInstance(ClassType: new () => any) {
+                    return new ClassType();
+                }
+
+                const instance = createInstance(class {
+                    sayHello() {
+                        console.log("Hello from an inline class!");
+                    }
+                });
+            `)
+        );
+    });
+
+    test.skip('inner class declaration with extends', () => {
       rewriteRun(
         //language=typescript
         typeScript(`
@@ -230,18 +292,7 @@ describe('class mapping', () => {
             const a: typeof OuterClass.InnerClass.prototype = 1;
         `)
       );
-  });
-
-  test.skip('nested class qualified name', () => {
-      rewriteRun(
-          //language=typescript
-          typeScript(`
-              class OuterClass extends (class extends Number { }) {
-              }
-              const a: typeof OuterClass.InnerClass.prototype = 1;
-          `)
-      );
-  });
+    });
 
     test('class with optional properties, ctor and modifiers', () => {
         rewriteRun(

--- a/openrewrite/test/javascript/parser/function.test.ts
+++ b/openrewrite/test/javascript/parser/function.test.ts
@@ -108,6 +108,17 @@ describe('function mapping', () => {
         );
     });
 
+    test('function with type ref', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                function getLength(arr: Array<string>): number {
+                    return arr.length;
+                }
+            `)
+        );
+    });
+
     test.skip('function type with parameter', () => {
         rewriteRun(
             //language=typescript


### PR DESCRIPTION
Implemented `ClassExpression` via `JS.StatementExpression` as an `ClassDeclaration` wrapper.

Refactored `visitQualifiedName` and generalized `visitTypeReference`
