### PR TITLE
Use new socket for each source file

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
@@ -96,7 +96,7 @@ public class JavaScriptParser implements Parser {
             assert client != null;
             assert remotingContext != null;
             try (EncodingDetectingInputStream is = input.getSource(ctx)) {
-                SourceFile parsed = client.runUsingSocket((socket, messenger) -> requireNonNull(messenger.sendRequest(generator -> {
+                SourceFile parsed = client.withNewSocket((socket, messenger) -> requireNonNull(messenger.sendRequest(generator -> {
                             if (input.isSynthetic() || !Files.isRegularFile(input.getPath())) {
                                 generator.writeString("parse-source");
                                 generator.writeString(is.readFully());
@@ -109,7 +109,6 @@ public class JavaScriptParser implements Parser {
                             Tree tree = RemotingMessenger.receiveTree(remotingContext, parser,null);
                             return (SourceFile) tree;
                         }, socket)))
-                        .withSourcePath(path)
                         .withFileAttributes(FileAttributes.fromPath(input.getPath()))
                         .withCharset(getCharset(ctx));
 


### PR DESCRIPTION
As a workaround for the issue we have with the JS process returning the LST for a previously parsed source file, the Java parser frontend now creates a new socket for each source file being parsed.
