### PR TITLE
Throwing FlowSyntaxNotSupportedError if meets @flow annotation in a source file

### DIFF
--- a/openrewrite/test/javascript/parser/empty.test.ts
+++ b/openrewrite/test/javascript/parser/empty.test.ts
@@ -7,7 +7,7 @@ describe('empty mapping', () => {
     test('simple', () => {
         rewriteRun(
           //language=typescript
-          typeScript('if (true) ;')
+          typeScript('if (true) {/*a*/};')
         );
     });
 });

--- a/openrewrite/test/javascript/parser/flowAnnotation.test.ts
+++ b/openrewrite/test/javascript/parser/flowAnnotation.test.ts
@@ -1,0 +1,49 @@
+import {connect, disconnect, javaScript, rewriteRun, typeScript} from '../testHarness';
+
+describe('flow annotation checking test', () => {
+    beforeAll(() => connect());
+    afterAll(() => disconnect());
+
+    test('@flow in a comment in js', () => {
+        const faultyTest = () => rewriteRun(
+            //language=javascript
+            javaScript(`
+                //@flow
+
+                import Rocket from './rocket';
+                import RocketLaunch from './rocket-launch';
+            `)
+        );
+
+        expect(faultyTest).toThrow(/FlowSyntaxNotSupportedError/);
+    });
+
+    test('@flow in a multiline comment in js', () => {
+        const faultyTest = () => rewriteRun(
+            //language=javascript
+            javaScript(`
+                /*
+                    @flow
+                */
+
+                import Rocket from './rocket';
+                import RocketLaunch from './rocket-launch';
+            `)
+        );
+
+        expect(faultyTest).toThrow(/FlowSyntaxNotSupportedError/);
+    });
+
+    test('@flow in a comment in ts', () => {
+        rewriteRun(
+            //language=typescript
+            typeScript(`
+                //@flow
+
+                import Rocket from './rocket';
+                import RocketLaunch from './rocket-launch';
+            `)
+        );
+    });
+
+});


### PR DESCRIPTION
If a source file contains `@flow` annotation, the `FlowSyntaxNotSupportedError` is thrown as a `ParseError`, and the file is skipped from parsing.

Also added code to check syntax errors before parsing

