### PR TITLE
Fix `JavaScriptVisitor` bug

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
@@ -93,8 +93,8 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
                 )
         );
         a = a.withParameters(
-                a.getParameters().getPadding().withParams(
-                        Objects.requireNonNull(ListUtils.map(a.getParameters().getPadding().getParams(),
+                a.getParameters().getPadding().withParameters(
+                        Objects.requireNonNull(ListUtils.map(a.getParameters().getPadding().getParameters(),
                                 param -> visitRightPadded(param, JRightPadded.Location.LAMBDA_PARAM, p)
                         ))
                 )
@@ -102,7 +102,6 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         a = a.withParameters(Objects.requireNonNull(visitAndCast(a.getParameters(), p)));
         a = a.withReturnTypeExpression(visitAndCast(a.getReturnTypeExpression(), p));
         a = a.getPadding().withBody(Objects.requireNonNull(visitLeftPadded(a.getPadding().getBody(), JsLeftPadded.Location.LAMBDA_ARROW, p)));
-        a = a.withBody(Objects.requireNonNull(visitAndCast(a.getBody(), p)));
         a = a.withType(visitType(a.getType(), p));
         return a;
     }


### PR DESCRIPTION
The `JS.ArrowFunction#body` property was visited twice.
